### PR TITLE
go back to SRID 900913

### DIFF
--- a/contrib/libosmium/osmium/geom/mercator_projection.hpp
+++ b/contrib/libosmium/osmium/geom/mercator_projection.hpp
@@ -46,15 +46,15 @@ namespace osmium {
 
         namespace detail {
 
-            constexpr double earth_radius_for_epsg3857 = 6378137.0;
-            constexpr double max_coordinate_epsg3857 = 20037508.34;
+            constexpr double earth_radius_for_epsg900913 = 6378137.0;
+            constexpr double max_coordinate_epsg900913 = 20037508.34;
 
             constexpr inline double lon_to_x(double lon) {
-                return earth_radius_for_epsg3857 * deg_to_rad(lon);
+                return earth_radius_for_epsg900913 * deg_to_rad(lon);
             }
 
             inline double lat_to_y_with_tan(double lat) { // not constexpr because math functions aren't
-                return earth_radius_for_epsg3857 * std::log(std::tan(osmium::geom::PI/4 + deg_to_rad(lat)/2));
+                return earth_radius_for_epsg900913 * std::log(std::tan(osmium::geom::PI/4 + deg_to_rad(lat)/2));
             }
 
 #ifdef OSMIUM_USE_SLOW_MERCATOR_PROJECTION
@@ -71,7 +71,7 @@ namespace osmium {
                     return lat_to_y_with_tan(lat);
                 }
 
-                return earth_radius_for_epsg3857 *
+                return earth_radius_for_epsg900913 *
                     ((((((((((-3.1112583378460085319e-23  * lat +
                                2.0465852743943268009e-19) * lat +
                                6.4905282018672673884e-18) * lat +
@@ -97,18 +97,18 @@ namespace osmium {
 #endif
 
             constexpr inline double x_to_lon(double x) {
-                return rad_to_deg(x) / earth_radius_for_epsg3857;
+                return rad_to_deg(x) / earth_radius_for_epsg900913;
             }
 
             inline double y_to_lat(double y) { // not constexpr because math functions aren't
-                return rad_to_deg(2 * std::atan(std::exp(y / earth_radius_for_epsg3857)) - osmium::geom::PI/2);
+                return rad_to_deg(2 * std::atan(std::exp(y / earth_radius_for_epsg900913)) - osmium::geom::PI/2);
             }
 
         } // namespace detail
 
         /**
          * The maximum latitude that can be projected with the Web Mercator
-         * (EPSG:3857) projection.
+         * (EPSG:900913) projection.
          */
         constexpr double MERCATOR_MAX_LAT = 85.0511288;
 
@@ -132,7 +132,7 @@ namespace osmium {
 
         /**
          * Functor that does projection from WGS84 (EPSG:4326) to "Web
-         * Mercator" (EPSG:3857)
+         * Mercator" (EPSG:900913)
          */
         class MercatorProjection {
 
@@ -143,7 +143,7 @@ namespace osmium {
             }
 
             int epsg() const noexcept {
-                return 3857;
+                return 900913;
             }
 
             std::string proj_string() const {

--- a/contrib/libosmium/osmium/geom/projection.hpp
+++ b/contrib/libosmium/osmium/geom/projection.hpp
@@ -125,7 +125,7 @@ namespace osmium {
          *
          * If this Projection is initialized with the constructor taking
          * an integer with the epsg code 4326, no projection is done. If it
-         * is initialized with epsg code 3857 the Osmium-internal
+         * is initialized with epsg code 900913 the Osmium-internal
          * implementation of the Mercator projection is used, otherwise this
          * falls back to using the proj.4 library. Note that this "magic" does
          * not work if you use any of the constructors taking a string.
@@ -160,7 +160,7 @@ namespace osmium {
             Coordinates operator()(osmium::Location location) const {
                 if (m_epsg == 4326) {
                     return Coordinates{location.lon(), location.lat()};
-                } else if (m_epsg == 3857) {
+                } else if (m_epsg == 900913) {
                     return Coordinates{detail::lon_to_x(location.lon()),
                                        detail::lat_to_y(location.lat())};
                 }

--- a/contrib/libosmium/osmium/geom/tile.hpp
+++ b/contrib/libosmium/osmium/geom/tile.hpp
@@ -66,7 +66,7 @@ namespace osmium {
          * the given zoom level.
          */
         inline constexpr double tile_extent_in_zoom(uint32_t zoom) noexcept {
-            return detail::max_coordinate_epsg3857 * 2 / num_tiles_in_zoom(zoom);
+            return detail::max_coordinate_epsg900913 * 2 / num_tiles_in_zoom(zoom);
         }
 
         /**
@@ -76,7 +76,7 @@ namespace osmium {
          */
         inline constexpr uint32_t mercx_to_tilex(uint32_t zoom, double x) noexcept {
             return static_cast<uint32_t>(detail::clamp<int32_t>(
-                static_cast<int32_t>((x + detail::max_coordinate_epsg3857) / tile_extent_in_zoom(zoom)),
+                static_cast<int32_t>((x + detail::max_coordinate_epsg900913) / tile_extent_in_zoom(zoom)),
                 0, num_tiles_in_zoom(zoom) -1
             ));
         }
@@ -88,7 +88,7 @@ namespace osmium {
          */
         inline constexpr uint32_t mercy_to_tiley(uint32_t zoom, double y) noexcept {
             return static_cast<uint32_t>(detail::clamp<int32_t>(
-                static_cast<int32_t>((detail::max_coordinate_epsg3857 - y) / tile_extent_in_zoom(zoom)),
+                static_cast<int32_t>((detail::max_coordinate_epsg900913 - y) / tile_extent_in_zoom(zoom)),
                 0, num_tiles_in_zoom(zoom) -1
             ));
         }

--- a/docs/export.md
+++ b/docs/export.md
@@ -5,7 +5,7 @@ Osm2pgsql can be used in combination with [ogr2ogr](http://www.gdal.org/ogr2ogr.
 An example command to export to GeoJSON would be
 
     ogr2ogr -f "GeoJSON" roads.geojson -t_srs EPSG:4326 \
-      PG:"dbname=gis" -s_srs EPSG:3857 \
+      PG:"dbname=gis" -s_srs EPSG:900913 \
       -sql "SELECT name,highway,oneway,toll,way FROM planet_osm_line WHERE highway IS NOT NULL"
 
 Care should be taken if exporting to shapefiles, as characters may be present

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -14,15 +14,15 @@ migration and a reload is required.
 
 ## 0.91 default projection ##
 
-The default projection was moved from 900913 to 3857. This does not effect
+The default projection was moved from 900913 to 900913. This does not effect
 users using `-l` or `-E`, but if using no projection options or `-m` a
 migration is needed.
 
 ```sql
-ALTER TABLE planet_osm_roads ALTER COLUMN way TYPE geometry(LineString,3857) USING ST_SetSRID(way,3857);
-ALTER TABLE planet_osm_point ALTER COLUMN way TYPE geometry(Point,3857) USING ST_SetSRID(way,3857);
-ALTER TABLE planet_osm_line ALTER COLUMN way TYPE geometry(LineString,3857) USING ST_SetSRID(way,3857);
-ALTER TABLE planet_osm_polygon ALTER COLUMN way TYPE geometry(Geometry,3857) USING ST_SetSRID(way,3857);
+ALTER TABLE planet_osm_roads ALTER COLUMN way TYPE geometry(LineString,900913) USING ST_SetSRID(way,900913);
+ALTER TABLE planet_osm_point ALTER COLUMN way TYPE geometry(Point,900913) USING ST_SetSRID(way,900913);
+ALTER TABLE planet_osm_line ALTER COLUMN way TYPE geometry(LineString,900913) USING ST_SetSRID(way,900913);
+ALTER TABLE planet_osm_polygon ALTER COLUMN way TYPE geometry(Geometry,900913) USING ST_SetSRID(way,900913);
 ```
 
 ## 0.88.0 z_order changes ##

--- a/docs/osm2pgsql.1
+++ b/docs/osm2pgsql.1
@@ -241,7 +241,7 @@ Verbose output.
 .SH SUPPORTED PROJECTIONS
 Latlong             (\-l) SRS:  4326 (none)
 .br
-Spherical Mercator  (\-m) SRS:3857 +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs +over
+Spherical Mercator  (\-m) SRS:900913 +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs +over
 .br
 EPSG-defined        (\-E) SRS: +init=epsg:(as given in parameter)
 .PP

--- a/reprojection.cpp
+++ b/reprojection.cpp
@@ -53,7 +53,7 @@ class merc_reprojection_t : public reprojection
 public:
     osmium::geom::Coordinates reproject(osmium::Location loc) const override
     {
-        /* The latitude co-ordinate is clipped at slightly larger than the 3857 'world'
+        /* The latitude co-ordinate is clipped at slightly larger than the 900913 'world'
          * extent of +-85.0511 degrees to ensure that the points appear just outside the
          * edge of the map. */
         double lat = loc.lat_without_check();

--- a/reprojection.hpp
+++ b/reprojection.hpp
@@ -13,7 +13,7 @@
 #include <osmium/geom/projection.hpp>
 #include <osmium/osm/location.hpp>
 
-enum Projection { PROJ_LATLONG = 4326, PROJ_SPHERE_MERC = 3857 };
+enum Projection { PROJ_LATLONG = 4326, PROJ_SPHERE_MERC = 900913 };
 
 class reprojection : public boost::noncopyable
 {
@@ -27,7 +27,7 @@ public:
     virtual osmium::geom::Coordinates reproject(osmium::Location loc) const = 0;
 
     /**
-     * Converts coordinates from target projection to tile projection (EPSG:3857)
+     * Converts coordinates from target projection to tile projection (EPSG:900913)
      *
      * Do not confuse with coords_to_tile which does *not* calculate coordinates in the
      * tile projection, but tile coordinates.

--- a/tests/test-options-projection.cpp
+++ b/tests/test-options-projection.cpp
@@ -67,7 +67,7 @@ static void test_no_options(pg::tempdb *db)
 {
     options_t options(DEF_PARAMS + 1, (char **) option_params);
     check_projection(options, "Spherical Mercator");
-    check_tables(db, options, "3857");
+    check_tables(db, options, "900913");
 }
 
 static void test_latlon_option(pg::tempdb *db)
@@ -83,7 +83,7 @@ static void test_merc_option(pg::tempdb *db)
     option_params[DEF_PARAMS] = "-m";
     options_t options(DEF_PARAMS + 2, (char **) option_params);
     check_projection(options, "Spherical Mercator");
-    check_tables(db, options, "3857");
+    check_tables(db, options, "900913");
 }
 
 static void test_e_option(pg::tempdb *db, const char *param,
@@ -107,7 +107,7 @@ int main()
     test_latlon_option(db.get());
     test_merc_option(db.get());
     test_e_option(db.get(), "4326", "Latlong");
-    test_e_option(db.get(), "3857", "Spherical Mercator");
+    test_e_option(db.get(), "900913", "Spherical Mercator");
     test_e_option(db.get(), "32632", nullptr);
 
     return 0;

--- a/tests/test-output-pgsql-area.cpp
+++ b/tests/test-output-pgsql-area.cpp
@@ -3,7 +3,7 @@
 Test the area reprojection functionality of osm2pgsql 
 
 The idea behind that functionality is to populate the way_area
-column with the area that a polygoun would have in EPSG:3857, 
+column with the area that a polygoun would have in EPSG:900913, 
 rather than the area it actually has in the coordinate system
 used for importing.
 

--- a/tests/test-output-pgsql.cpp
+++ b/tests/test-output-pgsql.cpp
@@ -101,7 +101,7 @@ void test_regression_simple() {
     db->check_number(143.845, "SELECT ST_Area(ST_Transform(way,4326)::geography) FROM osm2pgsql_test_polygon WHERE osm_id = 3265");
 
     // Check a point's location
-    db->check_count(1, "SELECT count(*) FROM osm2pgsql_test_point WHERE ST_DWithin(way, 'SRID=3857;POINT(1062645.12 5972593.4)'::geometry, 0.1)");
+    db->check_count(1, "SELECT count(*) FROM osm2pgsql_test_point WHERE ST_DWithin(way, 'SRID=900913;POINT(1062645.12 5972593.4)'::geometry, 0.1)");
 }
 
 void test_latlong() {


### PR DESCRIPTION
Original osm2pgsql switched to 3857 (which is the same, just a different ID), so I just replaced 3857 with 900913 everywhere